### PR TITLE
Exclude deleted collections from depositor summary.

### DIFF
--- a/src/main/java/org/chronopolis/remote/node/impl/DefaultRemoteNode.java
+++ b/src/main/java/org/chronopolis/remote/node/impl/DefaultRemoteNode.java
@@ -108,7 +108,7 @@ public class DefaultRemoteNode implements RemoteNode {
 
         List<org.chronopolis.remote.node.impl.jackson.ace.status.Collection> results = new ArrayList<>();
         for (org.chronopolis.remote.node.impl.jackson.ace.status.Collection aceCollection : aceCollections) {
-            if (aceCollection.getState() != "R") {
+            if (aceCollection.getState() != null && !"R".equalsIgnoreCase(aceCollection.getState())) {
                 results.add(aceCollection);
             }
         }

--- a/src/main/java/org/chronopolis/remote/node/impl/DefaultRemoteNode.java
+++ b/src/main/java/org/chronopolis/remote/node/impl/DefaultRemoteNode.java
@@ -125,6 +125,7 @@ public class DefaultRemoteNode implements RemoteNode {
             Map<String, DepositorSummary> depositor2summary = new TreeMap<>();
 
             AceSummaryStatus aceSummaryStatus = this.getAceSummaryStatusFromRemoteAce();
+            aceSummaryStatus.setCollections(excludeDeletedCollections(aceSummaryStatus.getCollections()));
 
             for (org.chronopolis.remote.node.impl.jackson.ace.status.Collection aceCollection : aceSummaryStatus.getCollections()) {
 

--- a/src/test/java/org/chronopolis/remote/node/impl/DefaultRemoteNodeTest.java
+++ b/src/test/java/org/chronopolis/remote/node/impl/DefaultRemoteNodeTest.java
@@ -192,14 +192,15 @@ public class DefaultRemoteNodeTest {
 
         List<org.chronopolis.remote.node.impl.jackson.ace.status.Collection> collectionList = new ArrayList<>();
 
-        collectionList.add(this.createDepositorCollection("ACADIS", "BAG 1", 100L, 200L));
-        collectionList.add(this.createDepositorCollection("ACADIS", "BAG 2", 1000L, 2000L));
-        collectionList.add(this.createDepositorCollection("UCSD", "BAG 3", 10000L, 20000L));
+        collectionList.add(this.createDepositorCollection("ACADIS", "BAG 1", 100L, 200L, "A"));
+        collectionList.add(this.createDepositorCollection("ACADIS", "BAG 2", 1000L, 2000L, "A"));
+        collectionList.add(this.createDepositorCollection("UCSD", "BAG 3", 10000L, 20000L, "A"));
+        collectionList.add(this.createDepositorCollection("UCSD", "BAG 4", 10000L, 20000L, "R"));
 
         return collectionList;
     }
 
-    private org.chronopolis.remote.node.impl.jackson.ace.status.Collection createDepositorCollection(String depositor, String bagName, long totalFiles, long totalSize) {
+    private org.chronopolis.remote.node.impl.jackson.ace.status.Collection createDepositorCollection(String depositor, String bagName, long totalFiles, long totalSize, String state) {
 
         org.chronopolis.remote.node.impl.jackson.ace.status.Collection collection = new org.chronopolis.remote.node.impl.jackson.ace.status.Collection();
 
@@ -207,6 +208,7 @@ public class DefaultRemoteNodeTest {
         collection.setName(bagName);
         collection.setTotalFiles(totalFiles);
         collection.setTotalSize(totalSize);
+        collection.setState(state);
 
         return collection;
     }

--- a/src/test/java/org/chronopolis/remote/node/impl/DefaultRemoteNodeTest.java
+++ b/src/test/java/org/chronopolis/remote/node/impl/DefaultRemoteNodeTest.java
@@ -117,19 +117,21 @@ public class DefaultRemoteNodeTest {
 
         List<org.chronopolis.remote.node.impl.jackson.ace.status.Collection> collectionList = new ArrayList<>();
 
-        collectionList.add(this.createCollection(100L, 200L));
-        collectionList.add(this.createCollection(1000L, 2000L));
-        collectionList.add(this.createCollection(10000L, 20000L));
+        collectionList.add(this.createCollection(100L, 200L, "A"));
+        collectionList.add(this.createCollection(1000L, 2000L, "A"));
+        collectionList.add(this.createCollection(10000L, 20000L, "A"));
+        collectionList.add(this.createCollection(10L, 20L, "R"));
 
         return collectionList;
     }
 
-    private org.chronopolis.remote.node.impl.jackson.ace.status.Collection createCollection(long totalFiles, long totalSize) {
+    private org.chronopolis.remote.node.impl.jackson.ace.status.Collection createCollection(long totalFiles, long totalSize, String state) {
 
         org.chronopolis.remote.node.impl.jackson.ace.status.Collection collection = new org.chronopolis.remote.node.impl.jackson.ace.status.Collection();
 
         collection.setTotalFiles(totalFiles);
         collection.setTotalSize(totalSize);
+        collection.setState(state);
 
         return collection;
     }


### PR DESCRIPTION
Related to #1 

- Fix the state value comparing bug and update test for status summary.
- Exclude deleted collections from depositor summary.