### PR TITLE
Add copy button to copy aceSummary table and change to lighter striped color.

### DIFF
--- a/src/client/app/css/chrondash.css
+++ b/src/client/app/css/chrondash.css
@@ -30,6 +30,24 @@ th, td {
 	font-weight: bold;
 }
 
+.btn-content-copy {
+  border: none;
+  background-color: #fff;
+  margin-top: -24px;
+  margin-right: 6px;
+  float: right;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.btn-content-copy:hover {
+  color: #ccc;
+}
+
+table tbody tr:nth-child(odd) {
+  background-color: #f5f5f5;
+}
+
 /*
  * html elements (and their children) that are tagged with the ngCloak directive
  * are hidden until the template has completed compilation.

--- a/src/client/app/index.jsp
+++ b/src/client/app/index.jsp
@@ -83,6 +83,7 @@
 	<script src="services/formatting.js"></script>
 	<script src="services/navigation.js"></script>
 	<script src="js/alertMessage.js"></script>
+	<script src="js/copyToClipboard.js"></script>
 
 	<!-- load the theme. otherwise, remove to use default bootsrap skin. -->
 	<script src="js/theme-ucsd.js"></script>

--- a/src/client/app/js/copyToClipboard.js
+++ b/src/client/app/js/copyToClipboard.js
@@ -1,0 +1,22 @@
+/** Copy HTML element with styles to clipboard */
+function copyToClipboard(containerId) {
+  var container = document.getElementById(containerId);
+  if (document.selection) { 
+    var range = document.body.createTextRange();
+    range.moveToElementText(container);
+    range.select().createTextRange();
+    document.execCommand("copy"); 
+  } else if (window.getSelection) {
+    var range = document.createRange();
+    try {
+      range.selectNodeContents(objTgt);
+    } catch (eCapture) {
+      range.selectNode(container);
+    }
+
+    var selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    document.execCommand("copy");
+  }
+}

--- a/src/client/app/views/aceDepositor.html
+++ b/src/client/app/views/aceDepositor.html
@@ -6,7 +6,7 @@
 
 		<div class="table-responsive cd-responsive">
 			<table class="table table-striped">
-				<thead class="thead-dark">
+				<thead class="thead-light">
 					<tr>
 						<th>Depositor</th>
 						<th ng-repeat="server in servers | orderBy: 'node'">{{ server.node }}</th>

--- a/src/client/app/views/aceSummary.html
+++ b/src/client/app/views/aceSummary.html
@@ -5,9 +5,11 @@
 	<div class="col">
 
 		<h3>Production</h3>
-
-		<table class="table table-sm table-striped">
-			<thead class="thead-dark">
+		<button class="btn-content-copy" onclick="copyToClipboard('production')" title="Copy to clipboard">
+			Copy
+		</button>
+		<table id="production" class="table table-bordered">
+			<thead>
 				<tr class="d-flex">
 					<th class="col-3" scope="col">Node</th>
 					<th class="col-3" scope="col">Disk Used</th>
@@ -47,9 +49,11 @@
 	<div class="col">
 
 		<h3>Test</h3>
-
-		<table class="table table-sm table-striped">
-			<thead class="thead-dark">
+		<button class="btn-content-copy" onclick="copyToClipboard('test')" title="Copy to clipboard">
+			Copy
+		</button>
+		<table id="test" class="table table-sm table-bordered">
+			<thead>
 				<tr class="d-flex">
 					<th class="col-3" scope="col">Node</th>
 					<th class="col-3" scope="col">Disk Used</th>

--- a/src/client/app/views/home.html
+++ b/src/client/app/views/home.html
@@ -7,7 +7,7 @@
 		<h3>Production</h3>
 
 		<table class="table table-sm table-striped">
-			<thead class="thead-dark">
+			<thead class="thead-light">
 				<tr class="d-flex">
 					<th class="col-4" scope="col">Node</th>
 					<th class="col-4" scope="col">Ace Status</th>
@@ -55,7 +55,7 @@
 		<h3>Test</h3>
 
 		<table class="table table-sm table-striped">
-			<thead class="thead-dark">
+			<thead class="thead-light">
 				<tr class="d-flex">
 					<th class="col-4" scope="col">Node</th>
 					<th class="col-4" scope="col">Ace Status</th>

--- a/src/client/app/views/ingestStatus.html
+++ b/src/client/app/views/ingestStatus.html
@@ -35,7 +35,7 @@
 
 		<div class="table-responsive cd-responsive">
 			<table class="table table-striped">
-				<thead class="thead-dark">
+				<thead class="thead-light">
 					<tr>
 						<th>Bag Identifier</th>
 						<th>Disk Used</th>


### PR DESCRIPTION
Related to #4 

- Change ace summary table to lighter header and striped color.
- Add copy button to  help coping aceSummary table content.


Screenshots:
- ACE Summary table when clicking on the `Copy` button on top-right of the table.

Node | Disk Used | Num Bags | Num Files
-- | -- | -- | --
ucsd | 9.77 KiB / 10.00 KB | 3 | 1


- ACE Summary table
<img width="1440" alt="Screen Shot - chron-dashboard-ace-summary" src="https://user-images.githubusercontent.com/2430784/190008739-ec737f4c-a0c1-4ed4-b93f-cb1786836683.png">

- Depositor Summary page
<img width="1440" alt="Screen Shot - chron-dashboard-depositor-summary" src="https://user-images.githubusercontent.com/2430784/190008910-bde73b49-a23d-461d-98c6-9d05b9cceede.png">

-  Home page
<img width="1439" alt="Screen Shot - chron-dashboard-home" src="https://user-images.githubusercontent.com/2430784/190008824-efb765ec-c11d-49f9-b57f-62168799450d.png">


