### PR TITLE
Replace Copy button with small font awesome icon.

### DIFF
--- a/src/client/app/index.jsp
+++ b/src/client/app/index.jsp
@@ -6,6 +6,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
 		<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">		
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 		<link rel="stylesheet" href="css/chrondash.css">
 		<title>Chronopolis Dashboard</title>
 	</head>

--- a/src/client/app/views/aceSummary.html
+++ b/src/client/app/views/aceSummary.html
@@ -6,7 +6,7 @@
 
 		<h3>Production</h3>
 		<button class="btn-content-copy" onclick="copyToClipboard('production')" title="Copy to clipboard">
-			Copy
+			<i class="fa fa-copy" style="font-size:16px;color:#555;"></i>
 		</button>
 		<table id="production" class="table table-bordered">
 			<thead>
@@ -50,7 +50,7 @@
 
 		<h3>Test</h3>
 		<button class="btn-content-copy" onclick="copyToClipboard('test')" title="Copy to clipboard">
-			Copy
+			<i class="fa fa-copy" style="font-size:16px;color:#555;"></i>
 		</button>
 		<table id="test" class="table table-sm table-bordered">
 			<thead>


### PR DESCRIPTION
Related ticket #4 

Replace Copy button with small font awesome icon for ACE Summary tables copying.

Screenshots:
<img width="1438" alt="Screen Shot - dashboard copy" src="https://user-images.githubusercontent.com/2430784/193335874-f6853a8a-beac-4173-95f1-043697b73e53.png">
